### PR TITLE
fix: fixed the center-icon-container to have relative positioning

### DIFF
--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.scss
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.scss
@@ -85,7 +85,7 @@ $background-orange: orange;
   display: flex;
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: relative;
   height: 10px;
   width: 10px;
   background: white;


### PR DESCRIPTION
Fixes #18

Changed positioning of the `center-icon-container` to relative instead of absolute.