### PR TITLE
Fix: remove debug console output

### DIFF
--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
@@ -88,11 +88,9 @@ export class NgxTimelineComponent implements OnInit, OnChanges, DoCheck {
 
   ngOnChanges() {
     this.groupEvents(this.events);
-    console.log('ngOnChanges');
   }
 
   ngDoCheck() {
-    console.log('ngDoCheck');
     const changes = this.iterableDiffer.diff(this.events);
     if (changes) {
       this.groupEvents(this.events);


### PR DESCRIPTION
Console output should not be used for release builds.