### PR TITLE
feat!: strict type for `langCode`

### DIFF
--- a/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.spec.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.spec.ts
@@ -79,10 +79,5 @@ describe('NgxTimelineEventComponent', () => {
       const res = component.getDateObj();
       expect(res).toEqual({day: '19', month: 'ago', year: 2021});
     });
-    it('should getDateObj with unsupported langCode', () => {
-      component.langCode = 'xx';
-      const res = component.getDateObj();
-      expect(res).toEqual({day: '19', month: 'Aug', year: 2021});
-    });
   });
 });

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.ts
@@ -2,7 +2,7 @@ import {DatePipe} from '@angular/common';
 import {Component, Input, Output, TemplateRef} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
-import {NgxTimelineOrientation, supportedLanguageCodes} from '../../models';
+import {defaultSupportedLanguageCode, NgxTimelineOrientation, SupportedLanguageCode} from '../../models';
 import {NgxTimelineItem, NgxTimelineItemPosition} from '../../models/NgxTimelineEvent';
 
 @Component({
@@ -22,7 +22,7 @@ export class NgxTimelineEventComponent {
   /**
    * Language code used to format the dates
    */
-  @Input() langCode?: string;
+  @Input() langCode: SupportedLanguageCode = defaultSupportedLanguageCode;
   /**
    * Inner custom template used to display the event detail
    */
@@ -68,7 +68,7 @@ export class NgxTimelineEventComponent {
     return {day, month, year};
   }
 
-  protected getLangCode(): string {
-    return this.langCode && supportedLanguageCodes.includes(this.langCode) ? this.langCode : supportedLanguageCodes[0];
+  protected getLangCode(): SupportedLanguageCode {
+    return this.langCode;
   }
 }

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
@@ -12,8 +12,9 @@ import {
   NgxTimelineEventChangeSide,
   periodKeyDateFormat,
   fieldsToCheckEventChangeSideInGroup as fieldsToCheckEventChangeSide,
-  fieldsToAddEventGroup} from '../models';
-  
+  fieldsToAddEventGroup, SupportedLanguageCode, defaultSupportedLanguageCode,
+} from '../models';
+
 
 @Component({
   selector: 'ngx-timeline',
@@ -28,7 +29,7 @@ export class NgxTimelineComponent implements OnInit, OnChanges, DoCheck {
   /**
    * Language code used to show the date formatted
    */
-  @Input() langCode?: string;
+  @Input() langCode: SupportedLanguageCode = defaultSupportedLanguageCode;
   /**
    * Boolean used to enable or disable the animations
    */

--- a/projects/ngx-timeline/src/lib/models/NgxConfigObj.ts
+++ b/projects/ngx-timeline/src/lib/models/NgxConfigObj.ts
@@ -1,4 +1,6 @@
-export const supportedLanguageCodes = ['en', 'it', 'fr', 'de', 'es', 'sl', 'tr', 'pl', 'pt', 'ru'];
+export const supportedLanguageCodes = ['en', 'it', 'fr', 'de', 'es', 'sl', 'tr', 'pl', 'pt', 'ru'] as const;
+export type SupportedLanguageCode = typeof supportedLanguageCodes[number];
+export const defaultSupportedLanguageCode: SupportedLanguageCode = supportedLanguageCodes[0];
 
 export interface NgxConfigDate {
   code: string;
@@ -9,9 +11,9 @@ export interface NgxConfigDate {
   year: string;
 }
 
-export interface NgxDateObjMap {
-  [key: string]: NgxConfigDate;
-}
+export type NgxDateObjMap = {
+  [key in SupportedLanguageCode]: NgxConfigDate;
+};
 
 export const dateConfigMap: NgxDateObjMap = {
   en: {

--- a/projects/ngx-timeline/src/lib/pipes/ngx-date-pipe.ts
+++ b/projects/ngx-timeline/src/lib/pipes/ngx-date-pipe.ts
@@ -1,14 +1,14 @@
 import {DatePipe} from '@angular/common';
 import {Pipe, PipeTransform} from '@angular/core';
 
-import {NgxConfigDate, supportedLanguageCodes, fieldConfigDate, dateConfigMap} from '../models';
+import {dateConfigMap, defaultSupportedLanguageCode, fieldConfigDate, NgxConfigDate, SupportedLanguageCode} from '../models';
 
 @Pipe({name: 'ngxdate', pure: false})
 export class NgxDatePipe implements PipeTransform {
   constructor() {
   }
 
-  transform(date: Date | string, dateFormat?: string, langCode?: string): string {
+  transform(date: Date | string, dateFormat?: string, langCode?: SupportedLanguageCode): string {
     let transformedDate = null;
     if (date) {
       const objDate = this.getDateConfig(langCode);
@@ -21,9 +21,8 @@ export class NgxDatePipe implements PipeTransform {
     return configDate[fieldConfigDate[dateFormat]];
   }
 
-  private getDateConfig(langCode: string): NgxConfigDate {
-    const code = langCode || supportedLanguageCodes[0];
-    const configDate = dateConfigMap[code] || dateConfigMap[supportedLanguageCodes[0]];
-    return configDate;
+  private getDateConfig(langCode?: SupportedLanguageCode): NgxConfigDate {
+    const code: SupportedLanguageCode = langCode ?? defaultSupportedLanguageCode;
+    return dateConfigMap[code];
   }
 }


### PR DESCRIPTION
Change type: string -> SupportedLanguageCode

langCode can be typesafe. Compile error will be thrown if unsupported language is accidentally used.