### PR TITLE
chore(lib): migrate to standalone

### DIFF
--- a/projects/ngx-timeline/.eslintrc.json
+++ b/projects/ngx-timeline/.eslintrc.json
@@ -23,6 +23,7 @@
         ]
       },
       "rules": {
+        "@angular-eslint/prefer-standalone": "warn",
         "@angular-eslint/directive-selector": [
           "error",
           {

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.spec.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.spec.ts
@@ -33,9 +33,8 @@ describe('NgxTimelineEventComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [NgxTimelineEventComponent],
-    })
-        .compileComponents();
+      imports: [NgxTimelineEventComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline-event/ngx-timeline-event.component.ts
@@ -1,4 +1,4 @@
-import {DatePipe} from '@angular/common';
+import {DatePipe, NgClass, NgTemplateOutlet, TitleCasePipe} from '@angular/common';
 import {Component, Input, Output, TemplateRef} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
@@ -7,8 +7,14 @@ import {NgxTimelineItem, NgxTimelineItemPosition} from '../../models/NgxTimeline
 
 @Component({
   selector: 'ngx-timeline-event',
+  standalone: true,
   templateUrl: './ngx-timeline-event.component.html',
-  styleUrls: ['./ngx-timeline-event.component.scss'],
+  styleUrl: './ngx-timeline-event.component.scss',
+  imports: [
+    NgClass,
+    NgTemplateOutlet,
+    TitleCasePipe,
+  ],
 })
 export class NgxTimelineEventComponent {
   /**

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.spec.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.spec.ts
@@ -9,9 +9,8 @@ describe('NgxTimelineComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [NgxTimelineComponent],
-    })
-        .compileComponents();
+      imports: [NgxTimelineComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
@@ -1,6 +1,8 @@
-import {Component, OnInit, Input, TemplateRef, OnChanges, Output, IterableDiffers, IterableDiffer, DoCheck, inject} from '@angular/core';
+import {NgClass, NgTemplateOutlet} from '@angular/common';
+import {Component, DoCheck, inject, Input, IterableDiffer, IterableDiffers, OnChanges, OnInit, Output, TemplateRef} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
+import {NgxTimelineEventComponent} from './ngx-timeline-event/ngx-timeline-event.component';
 import {
   NgxTimelineEvent,
   NgxTimelineItem,
@@ -14,12 +16,20 @@ import {
   fieldsToCheckEventChangeSideInGroup as fieldsToCheckEventChangeSide,
   fieldsToAddEventGroup, SupportedLanguageCode, defaultSupportedLanguageCode,
 } from '../models';
+import {NgxDatePipe} from '../pipes';
 
 
 @Component({
   selector: 'ngx-timeline',
+  standalone: true,
   templateUrl: './ngx-timeline.component.html',
-  styleUrls: ['./ngx-timeline.component.scss'],
+  styleUrl: './ngx-timeline.component.scss',
+  imports: [
+    NgClass,
+    NgTemplateOutlet,
+    NgxDatePipe,
+    NgxTimelineEventComponent,
+  ],
 })
 export class NgxTimelineComponent implements OnInit, OnChanges, DoCheck {
   /**

--- a/projects/ngx-timeline/src/lib/ngx-timeline.module.ts
+++ b/projects/ngx-timeline/src/lib/ngx-timeline.module.ts
@@ -10,8 +10,7 @@ import localeSl from '@angular/common/locales/sl';
 import localeTr from '@angular/common/locales/tr';
 import {NgModule} from '@angular/core';
 
-import {NgxTimelineEventComponent,NgxTimelineComponent}
-  from './components';
+import {NgxTimelineEventComponent, NgxTimelineComponent} from './components';
 import {NgxDatePipe} from './pipes';
 
 registerLocaleData(localeIt);
@@ -25,8 +24,8 @@ registerLocaleData(localePt);
 registerLocaleData(localeRu);
 
 @NgModule({
-  declarations: [NgxTimelineComponent, NgxTimelineEventComponent, NgxDatePipe],
-  imports: [CommonModule],
+  declarations: [],
+  imports: [CommonModule, NgxTimelineComponent, NgxTimelineEventComponent, NgxDatePipe],
   exports: [NgxTimelineComponent, NgxDatePipe],
 })
 export class NgxTimelineModule { }

--- a/projects/ngx-timeline/src/lib/pipes/ngx-date-pipe.ts
+++ b/projects/ngx-timeline/src/lib/pipes/ngx-date-pipe.ts
@@ -3,7 +3,11 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 import {dateConfigMap, defaultSupportedLanguageCode, fieldConfigDate, NgxConfigDate, SupportedLanguageCode} from '../models';
 
-@Pipe({name: 'ngxdate', pure: false})
+@Pipe({
+  name: 'ngxdate',
+  standalone: true,
+  pure: false,
+})
 export class NgxDatePipe implements PipeTransform {
   constructor() {
   }


### PR DESCRIPTION
Keeps the ngModule to provide backwards compatibility.