### PR TITLE
 fix(type): missing return types 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
         "plugin:@angular-eslint/recommended",
         "plugin:@angular-eslint/template/process-inline-templates",
         // "plugin:@angular-eslint/all", // more pedantic tests =)
-        // "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended",
         // "plugin:@typescript-eslint/recommended-type-checked",
         // "plugin:@typescript-eslint/stylistic",
         // "plugin:@typescript-eslint/stylistic-type-checked",
@@ -30,6 +30,8 @@
       ],
       "rules": {
         "quotes": ["error", "single"],
+        "@typescript-eslint/explicit-function-return-type": "warn",
+        "@typescript-eslint/no-explicit-any": "off",
         "import/order": [
           "error",
           {

--- a/projects/ngx-timeline/.eslintrc.json
+++ b/projects/ngx-timeline/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../.eslintrc.json",
   "ignorePatterns": [
-    "!**/*"
+    "!**/*",
+    "cypress/**/*"
   ],
   "settings": {
     "import/resolver": {

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
@@ -2,7 +2,6 @@ import {NgClass, NgTemplateOutlet} from '@angular/common';
 import {Component, DoCheck, inject, Input, IterableDiffer, IterableDiffers, OnChanges, OnInit, Output, TemplateRef} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
-import {NgxTimelineEventComponent} from './ngx-timeline-event/ngx-timeline-event.component';
 import {
   NgxTimelineEvent,
   NgxTimelineItem,
@@ -17,6 +16,7 @@ import {
   fieldsToAddEventGroup, SupportedLanguageCode, defaultSupportedLanguageCode,
 } from '../models';
 import {NgxDatePipe} from '../pipes';
+import {NgxTimelineEventComponent} from './ngx-timeline-event/ngx-timeline-event.component';
 
 
 @Component({

--- a/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
+++ b/projects/ngx-timeline/src/lib/components/ngx-timeline.component.ts
@@ -105,11 +105,11 @@ export class NgxTimelineComponent implements OnInit, OnChanges, DoCheck {
     this.groupEvents(this.events);
   }
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     this.groupEvents(this.events);
   }
 
-  ngDoCheck() {
+  ngDoCheck(): void {
     const changes = this.iterableDiffer.diff(this.events);
     if (changes) {
       this.groupEvents(this.events);
@@ -222,7 +222,7 @@ export class NgxTimelineComponent implements OnInit, OnChanges, DoCheck {
     };
   }
 
-  private shouldChangeEventsInPeriod() {
+  private shouldChangeEventsInPeriod(): boolean {
     return [NgxTimelineEventChangeSide.ALL_IN_GROUP, NgxTimelineEventChangeSide.ALL].indexOf(this.changeSide) != -1;
   }
 


### PR DESCRIPTION
Some functions have no explicit return type. Add eslint rule to enforce.